### PR TITLE
chore: update job outputs to new schema

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -59,8 +59,8 @@ jobs:
           flutter --version
           
           ./.github/scripts/buildAndroid.sh beta "${{ secrets.KEYSTORE_PASSWORD }}" "${{ secrets.KEY_PASSWORD }}" "${{ secrets.KEY_ALIAS }}" "${{ secrets.APP_CENTER_SECRET }}"
-          echo "::set-output name=artifact-filepath::$(cat tmp_artifact_path.txt)"
-          echo "::set-output name=artifact-filename::$(cat tmp_artifact_name.txt)"
+          echo "artifact-filepath=$(cat tmp_artifact_path.txt)" >> $GITHUB_OUTPUT
+          echo "artifact-filename=$(cat tmp_artifact_name.txt)" >> $GITHUB_OUTPUT
 
       - name: Upload artifact
         uses: actions/upload-artifact@v1

--- a/.github/workflows/release_trigger.yml
+++ b/.github/workflows/release_trigger.yml
@@ -63,10 +63,10 @@ jobs:
         id: prepare-build
         run: |
           ./.github/scripts/buildAndroid.sh release "${{ secrets.KEYSTORE_PASSWORD }}" "${{ secrets.KEY_PASSWORD }}" "${{ secrets.KEY_ALIAS }}" "${{ secrets.APP_CENTER_SECRET }}"
-          echo "::set-output name=artifact-filepath::$(cat tmp_artifact_path.txt)"
-          echo "::set-output name=artifact-filename::$(cat tmp_artifact_name.txt)"
-          echo "::set-output name=artifact-filepath-latest::$(cat tmp_artifact_path_latest.txt)"
-          echo "::set-output name=artifact-filename-latest::$(cat tmp_artifact_name_latest.txt)"
+          echo "artifact-filepath=$(cat tmp_artifact_path.txt)" >> $GITHUB_OUTPUT
+          echo "artifact-filename=$(cat tmp_artifact_name.txt)" >> $GITHUB_OUTPUT
+          echo "artifact-filepath-latest=$(cat tmp_artifact_path_latest.txt)" >> $GITHUB_OUTPUT
+          echo "artifact-filename-latest=$(cat tmp_artifact_name_latest.txt)" >> $GITHUB_OUTPUT
 
       - name: Update In-App Update Config
         id: update-config
@@ -85,7 +85,7 @@ jobs:
           echo "Version: $appVersionName"
           echo "Version-Code: $appVersionCode"
           TAG="v$appVersionName+$appVersionCode"
-          echo "::set-output name=name::$TAG"
+          echo "name=$TAG" >> $GITHUB_OUTPUT
           git push origin :refs/tags/${TAG}
           git push origin :refs/tags/latest
           git tag ${TAG}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: A SoundCloud app for FireTV.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.8+158
+version: 1.3.8+159
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
see blog article: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/